### PR TITLE
modify the loss caculation in yolov3_head.py

### DIFF
--- a/models/yolov3_head.py
+++ b/models/yolov3_head.py
@@ -262,7 +262,7 @@ class YOLOv3Head(nn.Module):
                     self.iou_loss(pred[..., :4][coord_mask], target[..., :4][coord_mask])).sum() / batchsize
             tgt_scale = tgt_scale[...,:2]
             loss_xy = (tgt_scale*self.bcewithlog_loss(output[...,:2], l1_target[...,:2])).sum() / batchsize
-            loss_wh = (self.l1_loss(output[...,2:4], l1_target[...,2:4],tgt_scale)).sum() / batchsize
+            loss_wh = (tgt_scale*self.l1_loss(output[...,2:4], l1_target[...,2:4])).sum() / batchsize
             loss_l1 = loss_xy + loss_wh
             loss_obj = (obj_mask*(self.bcewithlog_loss(output[..., 4], target[..., 4]))).sum() / batchsize
             loss_cls = (cls_mask*(self.bcewithlog_loss(output[..., 5:], target[..., 5:]))).sum()/ batchsize


### PR DESCRIPTION
```
File "main.py", line 386, in main
    loss_dict = model.forward(imgs, targets, epoch)
  File "/home/workspace/git/python/detection/ASFF/models/yolov3_asff.py", line 149, in forward
    x, anchor_loss, iou_loss, l1_loss, conf_loss, cls_loss = header(fused, targets)
  File "/home/miniconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/workspace/git/python/detection/ASFF/models/yolov3_head.py", line 265, in forward
    loss_wh = (self.l1_loss(output[...,2:4], l1_target[...,2:4],tgt_scale)).sum() / batchsize
  File "/home/miniconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
TypeError: forward() takes 3 positional arguments but 4 were given
```

Hello, thank you for sharing your great idea and code.

When run training on the coco, I meet an error: `TypeError: forward() takes 3 positional arguments but 4 were given` as posted.  And in the code:

```
self.l1_loss = nn.L1Loss(reduction='none')
```

While https://github.com/ruinmessi/ASFF/blob/master/models/yolov3_head.py#L264-L266

```
loss_xy = (tgt_scale*self.bcewithlog_loss(output[...,:2], l1_target[...,:2])).sum() / batchsize
loss_wh = (self.l1_loss(output[...,2:4], l1_target[...,2:4]),tgt_scale)).sum() / batchsize
```

Maybe, it should be：

```
loss_xy = (tgt_scale*self.bcewithlog_loss(output[...,:2], l1_target[...,:2])).sum() / batchsize
loss_wh = (tgt_scale*self.l1_loss(output[...,2:4], l1_target[...,2:4])).sum() / batchsize
```